### PR TITLE
revise addr format and fill up with zeros

### DIFF
--- a/IPs/BRAM/component.xml
+++ b/IPs/BRAM/component.xml
@@ -18,7 +18,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>4c2e7c11</spirit:value>
+            <spirit:value>6592d1f7</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -34,7 +34,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>c7d6d0cd</spirit:value>
+            <spirit:value>181af258</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -250,7 +250,7 @@
       <spirit:file>
         <spirit:name>src/BRAM.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_c7d6d0cd</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_181af258</spirit:userFileType>
         <spirit:userFileType>IMPORTED_FILE</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
@@ -322,18 +322,18 @@
       <xilinx:displayName>BRAM32x32_v1_0</xilinx:displayName>
       <xilinx:definitionSource>package_project</xilinx:definitionSource>
       <xilinx:coreRevision>2</xilinx:coreRevision>
-      <xilinx:coreCreationDateTime>2022-05-17T06:33:32Z</xilinx:coreCreationDateTime>
+      <xilinx:coreCreationDateTime>2022-05-20T05:52:54Z</xilinx:coreCreationDateTime>
       <xilinx:tags>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@318b9341_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@3ef4580f_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@bfb2804_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@363477d4_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@e1fedcb_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@66a1430a_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@1a066718_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@4c4a805b_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@23a52613_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7eb9d709_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
       </xilinx:tags>
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
       <xilinx:xilinxVersion>2020.2</xilinx:xilinxVersion>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="78faa109"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="5042ed17"/>
       <xilinx:checksum xilinx:scope="ports" xilinx:value="65677a20"/>
       <xilinx:checksum xilinx:scope="parameters" xilinx:value="5c67ed5e"/>
     </xilinx:packagingInfo>

--- a/IPs/BRAM/src/BRAM.v
+++ b/IPs/BRAM/src/BRAM.v
@@ -226,7 +226,7 @@ RAMB36E1 #(
 	.INJECTSBITERR(), // 1-bit input: Inject a single bit error
 	// Port A Address/Control Signals: 16-bit (each) input: Port A address and control signals (read port
 	// when RAM_MODE="SDP")
-	.ADDRARDADDR({1'b1, ADDRARDADDR[11:2], 5'b11111}), // 16-bit input: A port address/Read address
+	.ADDRARDADDR({1'b0, ADDRARDADDR[11:0], 3'b000}), // 16-bit input: A port address/Read address
 	.CLKARDCLK(clka), // 1-bit input: A port clock/Read clock
 	.ENARDEN(ENARDEN), // 1-bit input: A port enable/Read enable
 	.REGCEAREGCE(1), // 1-bit input: A port register enable/Register enable
@@ -238,7 +238,7 @@ RAMB36E1 #(
 	.DIPADIP(), // 4-bit input: A port parity/LSB parity
 	// Port B Address/Control Signals: 16-bit (each) input: Port B address and control signals (write port
 	// when RAM_MODE="SDP")
-	.ADDRBWRADDR({1'b1, ADDRBWRADDR[9:0], 5'b11111}), // 16-bit input: B port address/Write address
+	.ADDRBWRADDR({1'b0, ADDRBWRADDR[9:0], 5'b00000}), // 16-bit input: B port address/Write address
 	.CLKBWRCLK(clkb), // 1-bit input: B port clock/Write clock
 	.ENBWREN(ENBWREN), // 1-bit input: B port enable/Write enable
 	.REGCEB(1), // 1-bit input: B port register enable

--- a/IPs/SuperBRAM/component.xml
+++ b/IPs/SuperBRAM/component.xml
@@ -18,7 +18,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>bef5e70f</spirit:value>
+            <spirit:value>6c37d161</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -34,7 +34,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>e5246284</spirit:value>
+            <spirit:value>47585a28</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -284,7 +284,7 @@
       <spirit:file>
         <spirit:name>src/BRAM.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_e5246284</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_47585a28</spirit:userFileType>
         <spirit:userFileType>IMPORTED_FILE</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
@@ -356,18 +356,18 @@
       <xilinx:displayName>SuperBRAM32x32_v1_0</xilinx:displayName>
       <xilinx:definitionSource>package_project</xilinx:definitionSource>
       <xilinx:coreRevision>2</xilinx:coreRevision>
-      <xilinx:coreCreationDateTime>2022-05-17T06:29:33Z</xilinx:coreCreationDateTime>
+      <xilinx:coreCreationDateTime>2022-05-20T05:56:59Z</xilinx:coreCreationDateTime>
       <xilinx:tags>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@5fffbe43_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@271a02f8_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@2e3ab911_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@4b862cc2_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@1c9b5a3_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3f702289_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@361d798_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@5bc758b0_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7a38dd68_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@9e7478a_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
       </xilinx:tags>
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
       <xilinx:xilinxVersion>2020.2</xilinx:xilinxVersion>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="da94b76e"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="404f8371"/>
       <xilinx:checksum xilinx:scope="ports" xilinx:value="ddc37720"/>
       <xilinx:checksum xilinx:scope="parameters" xilinx:value="3cb5b8ab"/>
     </xilinx:packagingInfo>

--- a/IPs/SuperBRAM/src/BRAM.v
+++ b/IPs/SuperBRAM/src/BRAM.v
@@ -227,7 +227,7 @@ RAMB36E1 #(
 	.INJECTSBITERR(), // 1-bit input: Inject a single bit error
 	// Port A Address/Control Signals: 16-bit (each) input: Port A address and control signals (read port
 	// when RAM_MODE="SDP")
-	.ADDRARDADDR({1'b1, ADDRARDADDR[11:2], 5'b11111}), // 16-bit input: A port address/Read address
+	.ADDRARDADDR({1'b0, ADDRARDADDR[11:0], 3'b000}), // 16-bit input: A port address/Read address
 	.CLKARDCLK(clka), // 1-bit input: A port clock/Read clock
 	.ENARDEN(ENARDEN), // 1-bit input: A port enable/Read enable
 	.REGCEAREGCE(1), // 1-bit input: A port register enable/Register enable
@@ -239,7 +239,7 @@ RAMB36E1 #(
 	.DIPADIP(), // 4-bit input: A port parity/LSB parity
 	// Port B Address/Control Signals: 16-bit (each) input: Port B address and control signals (write port
 	// when RAM_MODE="SDP")
-	.ADDRBWRADDR({1'b1, ADDRBWRADDR[9:0], 5'b11111}), // 16-bit input: B port address/Write address
+	.ADDRBWRADDR({1'b0, ADDRBWRADDR[9:0], 5'b00000}), // 16-bit input: B port address/Write address
 	.CLKBWRCLK(clkb), // 1-bit input: B port clock/Write clock
 	.ENBWREN(ENBWREN), // 1-bit input: B port enable/Write enable
 	.REGCEB(1), // 1-bit input: B port register enable

--- a/src/BRAM.v
+++ b/src/BRAM.v
@@ -226,7 +226,7 @@ RAMB36E1 #(
 	.INJECTSBITERR(), // 1-bit input: Inject a single bit error
 	// Port A Address/Control Signals: 16-bit (each) input: Port A address and control signals (read port
 	// when RAM_MODE="SDP")
-	.ADDRARDADDR({1'b1, ADDRARDADDR[11:2], 5'b11111}), // 16-bit input: A port address/Read address
+	.ADDRARDADDR({1'b0, ADDRARDADDR[11:0], 3'b000}), // 16-bit input: A port address/Read address
 	.CLKARDCLK(clka), // 1-bit input: A port clock/Read clock
 	.ENARDEN(ENARDEN), // 1-bit input: A port enable/Read enable
 	.REGCEAREGCE(1), // 1-bit input: A port register enable/Register enable
@@ -238,7 +238,7 @@ RAMB36E1 #(
 	.DIPADIP(), // 4-bit input: A port parity/LSB parity
 	// Port B Address/Control Signals: 16-bit (each) input: Port B address and control signals (write port
 	// when RAM_MODE="SDP")
-	.ADDRBWRADDR({1'b1, ADDRBWRADDR[9:0], 5'b11111}), // 16-bit input: B port address/Write address
+	.ADDRBWRADDR({1'b0, ADDRBWRADDR[9:0], 5'b00000}), // 16-bit input: B port address/Write address
 	.CLKBWRCLK(clkb), // 1-bit input: B port clock/Write clock
 	.ENBWREN(ENBWREN), // 1-bit input: B port enable/Write enable
 	.REGCEB(1), // 1-bit input: B port register enable

--- a/src/SuperBRAM.v
+++ b/src/SuperBRAM.v
@@ -227,7 +227,7 @@ RAMB36E1 #(
 	.INJECTSBITERR(), // 1-bit input: Inject a single bit error
 	// Port A Address/Control Signals: 16-bit (each) input: Port A address and control signals (read port
 	// when RAM_MODE="SDP")
-	.ADDRARDADDR({1'b1, ADDRARDADDR[11:2], 5'b11111}), // 16-bit input: A port address/Read address
+	.ADDRARDADDR({1'b0, ADDRARDADDR[11:0], 3'b000}), // 16-bit input: A port address/Read address
 	.CLKARDCLK(clka), // 1-bit input: A port clock/Read clock
 	.ENARDEN(ENARDEN), // 1-bit input: A port enable/Read enable
 	.REGCEAREGCE(1), // 1-bit input: A port register enable/Register enable
@@ -239,7 +239,7 @@ RAMB36E1 #(
 	.DIPADIP(), // 4-bit input: A port parity/LSB parity
 	// Port B Address/Control Signals: 16-bit (each) input: Port B address and control signals (write port
 	// when RAM_MODE="SDP")
-	.ADDRBWRADDR({1'b1, ADDRBWRADDR[9:0], 5'b11111}), // 16-bit input: B port address/Write address
+	.ADDRBWRADDR({1'b0, ADDRBWRADDR[9:0], 5'b00000}), // 16-bit input: B port address/Write address
 	.CLKBWRCLK(clkb), // 1-bit input: B port clock/Write clock
 	.ENBWREN(ENBWREN), // 1-bit input: B port enable/Write enable
 	.REGCEB(1), // 1-bit input: B port register enable


### PR DESCRIPTION
The following changes are done: filling up address with 0 and revising Port A address format whch is identical to hw4.

```
.ADDRARDADDR({1'b0, ADDRARDADDR[11:0], 3'b000}), // 16-bit input: A port address/Read address
.ADDRBWRADDR({1'b0, ADDRBWRADDR[9:0], 5'b00000}), // 16-bit input: B port address/Write address
```
Please help me to verify the correctness, and no hesitate to tell me if there are any probability for improvement, Thanks!
