### PR TITLE
remove output reg from bram

### DIFF
--- a/IPs/BRAM/component.xml
+++ b/IPs/BRAM/component.xml
@@ -18,7 +18,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>6592d1f7</spirit:value>
+            <spirit:value>1ca3151a</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -34,7 +34,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>181af258</spirit:value>
+            <spirit:value>c42365c6</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -250,7 +250,7 @@
       <spirit:file>
         <spirit:name>src/BRAM.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_181af258</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_c42365c6</spirit:userFileType>
         <spirit:userFileType>IMPORTED_FILE</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
@@ -322,18 +322,18 @@
       <xilinx:displayName>BRAM32x32_v1_0</xilinx:displayName>
       <xilinx:definitionSource>package_project</xilinx:definitionSource>
       <xilinx:coreRevision>2</xilinx:coreRevision>
-      <xilinx:coreCreationDateTime>2022-05-20T05:52:54Z</xilinx:coreCreationDateTime>
+      <xilinx:coreCreationDateTime>2022-05-23T04:36:38Z</xilinx:coreCreationDateTime>
       <xilinx:tags>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@66a1430a_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@1a066718_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@4c4a805b_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@23a52613_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@7eb9d709_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@65ac0c2a_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@42fcb6ae_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3326c522_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@2972141e_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@4eeab1a4_ARCHIVE_LOCATION">d:/FPGA/IPs/BRAM</xilinx:tag>
       </xilinx:tags>
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
       <xilinx:xilinxVersion>2020.2</xilinx:xilinxVersion>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="5042ed17"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="dc6b415e"/>
       <xilinx:checksum xilinx:scope="ports" xilinx:value="65677a20"/>
       <xilinx:checksum xilinx:scope="parameters" xilinx:value="5c67ed5e"/>
     </xilinx:packagingInfo>

--- a/IPs/BRAM/src/BRAM.v
+++ b/IPs/BRAM/src/BRAM.v
@@ -23,8 +23,8 @@ RAMB36E1 #(
 	// Collision check: Values ("ALL", "WARNING_ONLY", "GENERATE_X_ONLY" or "NONE")
 	.SIM_COLLISION_CHECK("ALL"),
 	// DOA_REG, DOB_REG: Optional output register (0 or 1)
-	.DOA_REG(1),
-	.DOB_REG(1),
+	.DOA_REG(0),
+	.DOB_REG(0),
 	.EN_ECC_READ("FALSE"), // Enable ECC decoder,
 	// FALSE, TRUE
 	.EN_ECC_WRITE("FALSE"), // Enable ECC encoder,
@@ -229,7 +229,7 @@ RAMB36E1 #(
 	.ADDRARDADDR({1'b0, ADDRARDADDR[11:0], 3'b000}), // 16-bit input: A port address/Read address
 	.CLKARDCLK(clka), // 1-bit input: A port clock/Read clock
 	.ENARDEN(ENARDEN), // 1-bit input: A port enable/Read enable
-	.REGCEAREGCE(1), // 1-bit input: A port register enable/Register enable
+	.REGCEAREGCE(), // 1-bit input: A port register enable/Register enable
 	.RSTRAMARSTRAM(), // 1-bit input: A port set/reset
 	.RSTREGARSTREG(), // 1-bit input: A port register set/reset
 	.WEA(WEA), // 4-bit input: A port write enable
@@ -241,7 +241,7 @@ RAMB36E1 #(
 	.ADDRBWRADDR({1'b0, ADDRBWRADDR[9:0], 5'b00000}), // 16-bit input: B port address/Write address
 	.CLKBWRCLK(clkb), // 1-bit input: B port clock/Write clock
 	.ENBWREN(ENBWREN), // 1-bit input: B port enable/Write enable
-	.REGCEB(1), // 1-bit input: B port register enable
+	.REGCEB(), // 1-bit input: B port register enable
 	.RSTRAMB(), // 1-bit input: B port set/reset
 	.RSTREGB(), // 1-bit input: B port register set/reset
 	.WEBWE(), // 8-bit input: B port write enable/Write enable

--- a/IPs/SuperBRAM/component.xml
+++ b/IPs/SuperBRAM/component.xml
@@ -18,7 +18,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>6c37d161</spirit:value>
+            <spirit:value>aca91172</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -34,7 +34,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>47585a28</spirit:value>
+            <spirit:value>c6bb7d58</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -284,7 +284,7 @@
       <spirit:file>
         <spirit:name>src/BRAM.v</spirit:name>
         <spirit:fileType>verilogSource</spirit:fileType>
-        <spirit:userFileType>CHECKSUM_47585a28</spirit:userFileType>
+        <spirit:userFileType>CHECKSUM_c6bb7d58</spirit:userFileType>
         <spirit:userFileType>IMPORTED_FILE</spirit:userFileType>
       </spirit:file>
     </spirit:fileSet>
@@ -356,18 +356,18 @@
       <xilinx:displayName>SuperBRAM32x32_v1_0</xilinx:displayName>
       <xilinx:definitionSource>package_project</xilinx:definitionSource>
       <xilinx:coreRevision>2</xilinx:coreRevision>
-      <xilinx:coreCreationDateTime>2022-05-20T05:56:59Z</xilinx:coreCreationDateTime>
+      <xilinx:coreCreationDateTime>2022-05-23T04:33:33Z</xilinx:coreCreationDateTime>
       <xilinx:tags>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@3f702289_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@361d798_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@5bc758b0_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@7a38dd68_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@9e7478a_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@2c891f3f_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@487168a5_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@1ed79c69_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3a20bb3f_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@d0e84e2_ARCHIVE_LOCATION">d:/FPGA/IPs/SuperBRAM</xilinx:tag>
       </xilinx:tags>
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
       <xilinx:xilinxVersion>2020.2</xilinx:xilinxVersion>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="404f8371"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="f2c54327"/>
       <xilinx:checksum xilinx:scope="ports" xilinx:value="ddc37720"/>
       <xilinx:checksum xilinx:scope="parameters" xilinx:value="3cb5b8ab"/>
     </xilinx:packagingInfo>

--- a/IPs/SuperBRAM/src/BRAM.v
+++ b/IPs/SuperBRAM/src/BRAM.v
@@ -24,8 +24,8 @@ RAMB36E1 #(
 	// Collision check: Values ("ALL", "WARNING_ONLY", "GENERATE_X_ONLY" or "NONE")
 	.SIM_COLLISION_CHECK("ALL"),
 	// DOA_REG, DOB_REG: Optional output register (0 or 1)
-	.DOA_REG(1),
-	.DOB_REG(1),
+	.DOA_REG(0),
+	.DOB_REG(0),
 	.EN_ECC_READ("FALSE"), // Enable ECC decoder,
 	// FALSE, TRUE
 	.EN_ECC_WRITE("FALSE"), // Enable ECC encoder,
@@ -230,7 +230,7 @@ RAMB36E1 #(
 	.ADDRARDADDR({1'b0, ADDRARDADDR[11:0], 3'b000}), // 16-bit input: A port address/Read address
 	.CLKARDCLK(clka), // 1-bit input: A port clock/Read clock
 	.ENARDEN(ENARDEN), // 1-bit input: A port enable/Read enable
-	.REGCEAREGCE(1), // 1-bit input: A port register enable/Register enable
+	.REGCEAREGCE(), // 1-bit input: A port register enable/Register enable
 	.RSTRAMARSTRAM(), // 1-bit input: A port set/reset
 	.RSTREGARSTREG(), // 1-bit input: A port register set/reset
 	.WEA(WEA), // 4-bit input: A port write enable
@@ -242,7 +242,7 @@ RAMB36E1 #(
 	.ADDRBWRADDR({1'b0, ADDRBWRADDR[9:0], 5'b00000}), // 16-bit input: B port address/Write address
 	.CLKBWRCLK(clkb), // 1-bit input: B port clock/Write clock
 	.ENBWREN(ENBWREN), // 1-bit input: B port enable/Write enable
-	.REGCEB(1), // 1-bit input: B port register enable
+	.REGCEB(), // 1-bit input: B port register enable
 	.RSTRAMB(), // 1-bit input: B port set/reset
 	.RSTREGB(), // 1-bit input: B port register set/reset
 	.WEBWE({4'b0000,WEBWE}), // 8-bit input: B port write enable/Write enable

--- a/src/BRAM.v
+++ b/src/BRAM.v
@@ -23,8 +23,8 @@ RAMB36E1 #(
 	// Collision check: Values ("ALL", "WARNING_ONLY", "GENERATE_X_ONLY" or "NONE")
 	.SIM_COLLISION_CHECK("ALL"),
 	// DOA_REG, DOB_REG: Optional output register (0 or 1)
-	.DOA_REG(1),
-	.DOB_REG(1),
+	.DOA_REG(0),
+	.DOB_REG(0),
 	.EN_ECC_READ("FALSE"), // Enable ECC decoder,
 	// FALSE, TRUE
 	.EN_ECC_WRITE("FALSE"), // Enable ECC encoder,
@@ -229,7 +229,7 @@ RAMB36E1 #(
 	.ADDRARDADDR({1'b0, ADDRARDADDR[11:0], 3'b000}), // 16-bit input: A port address/Read address
 	.CLKARDCLK(clka), // 1-bit input: A port clock/Read clock
 	.ENARDEN(ENARDEN), // 1-bit input: A port enable/Read enable
-	.REGCEAREGCE(1), // 1-bit input: A port register enable/Register enable
+	.REGCEAREGCE(), // 1-bit input: A port register enable/Register enable
 	.RSTRAMARSTRAM(), // 1-bit input: A port set/reset
 	.RSTREGARSTREG(), // 1-bit input: A port register set/reset
 	.WEA(WEA), // 4-bit input: A port write enable
@@ -241,7 +241,7 @@ RAMB36E1 #(
 	.ADDRBWRADDR({1'b0, ADDRBWRADDR[9:0], 5'b00000}), // 16-bit input: B port address/Write address
 	.CLKBWRCLK(clkb), // 1-bit input: B port clock/Write clock
 	.ENBWREN(ENBWREN), // 1-bit input: B port enable/Write enable
-	.REGCEB(1), // 1-bit input: B port register enable
+	.REGCEB(), // 1-bit input: B port register enable
 	.RSTRAMB(), // 1-bit input: B port set/reset
 	.RSTREGB(), // 1-bit input: B port register set/reset
 	.WEBWE(), // 8-bit input: B port write enable/Write enable

--- a/src/SuperBRAM.v
+++ b/src/SuperBRAM.v
@@ -24,8 +24,8 @@ RAMB36E1 #(
 	// Collision check: Values ("ALL", "WARNING_ONLY", "GENERATE_X_ONLY" or "NONE")
 	.SIM_COLLISION_CHECK("ALL"),
 	// DOA_REG, DOB_REG: Optional output register (0 or 1)
-	.DOA_REG(1),
-	.DOB_REG(1),
+	.DOA_REG(0),
+	.DOB_REG(0),
 	.EN_ECC_READ("FALSE"), // Enable ECC decoder,
 	// FALSE, TRUE
 	.EN_ECC_WRITE("FALSE"), // Enable ECC encoder,
@@ -230,7 +230,7 @@ RAMB36E1 #(
 	.ADDRARDADDR({1'b0, ADDRARDADDR[11:0], 3'b000}), // 16-bit input: A port address/Read address
 	.CLKARDCLK(clka), // 1-bit input: A port clock/Read clock
 	.ENARDEN(ENARDEN), // 1-bit input: A port enable/Read enable
-	.REGCEAREGCE(1), // 1-bit input: A port register enable/Register enable
+	.REGCEAREGCE(), // 1-bit input: A port register enable/Register enable
 	.RSTRAMARSTRAM(), // 1-bit input: A port set/reset
 	.RSTREGARSTREG(), // 1-bit input: A port register set/reset
 	.WEA(WEA), // 4-bit input: A port write enable
@@ -242,7 +242,7 @@ RAMB36E1 #(
 	.ADDRBWRADDR({1'b0, ADDRBWRADDR[9:0], 5'b00000}), // 16-bit input: B port address/Write address
 	.CLKBWRCLK(clkb), // 1-bit input: B port clock/Write clock
 	.ENBWREN(ENBWREN), // 1-bit input: B port enable/Write enable
-	.REGCEB(1), // 1-bit input: B port register enable
+	.REGCEB(), // 1-bit input: B port register enable
 	.RSTRAMB(), // 1-bit input: B port set/reset
 	.RSTREGB(), // 1-bit input: B port register set/reset
 	.WEBWE({4'b0000,WEBWE}), // 8-bit input: B port write enable/Write enable


### PR DESCRIPTION
The output register is removed for both `BRAM `and `SuperBRAM`. I think #8 is due to this reason.
Except initail values, all settings are identical to hw4. Please help me to verify the correctness, Thanks ! QQ